### PR TITLE
Support stack limiting #10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ repositories {
 }
 
 group = 'org.whiley'
-version = '0.3.19'
+version = '0.3.20'
 
 java {
     withJavadocJar()

--- a/src/main/java/evmtools/Main.java
+++ b/src/main/java/evmtools/Main.java
@@ -43,6 +43,7 @@ public class Main {
 	private final Path inFile;
 	private final OutFile out;
 	private final int timeout = 10; // in seconds;
+	private int stackSize = 10;
 	private boolean prettify = false;
 	private boolean abbreviate = true;
 	private BiPredicate<String,StateTest.Instance> filter = (f,i) -> true;
@@ -67,6 +68,11 @@ public class Main {
 		return this;
 	}
 
+	private Main stackSize(int stackSize) {
+		this.stackSize = stackSize;
+		return this;
+	}
+
 	public void run() throws IOException, JSONException {
 		// Read contents of fixture file
 		String contents = Files.readString(inFile);
@@ -79,7 +85,7 @@ public class Main {
 	}
 
 	public JSONObject convertState2TraceTest(JSONObject stfile) throws JSONException {
-		Geth geth = new Geth().setTimeout(timeout * 1000);
+		Geth geth = new Geth().setTimeout(timeout * 1000).setStackSize(stackSize);
 		JSONObject json = new JSONObject();
 		// Convert
 		for (StateTest st : StateTest.fromJSON(stfile)) {

--- a/src/main/java/evmtools/util/Arrays.java
+++ b/src/main/java/evmtools/util/Arrays.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 ConsenSys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software dis-
+ * tributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package evmtools.util;
+
+import java.math.BigInteger;
+
+public class Arrays {
+	/**
+	 * Trim a given array to a given size by removing elements from the front. Note,
+	 * if the parameter is not larger than the <code>size</code>, then iis returned
+	 * untouched.
+	 *
+	 * @param size
+	 * @param items
+	 * @return
+	 */
+	public static <T> T[] trimFront(int size, T[] items) {
+		int n = items.length;
+		//
+		if (n <= size) {
+			return items;
+		} else {
+			return java.util.Arrays.copyOfRange(items, n - size, n);
+		}
+	}
+}


### PR DESCRIPTION
This puts in place a stack limit (which defaults to 10) that ensures the stack for a given execution step never has more than 10 items in it.  To make this work, we include a stack size parameter in the traces.