### PR TITLE
Support Updated StateTest format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ task gen(type: JavaExec) {
     // arguments to pass to the application
     args '-incremental'
     args '-forks'
-    args 'Berlin,London'
+    args 'Berlin,London,Shanghai'
     args '-dir'
     args 'fixtures'
     args '-out'

--- a/src/main/java/evmtools/core/Environment.java
+++ b/src/main/java/evmtools/core/Environment.java
@@ -30,6 +30,8 @@ public class Environment {
 	public final BigInteger currentNumber;
 	public final BigInteger currentTimestamp;
 	public final BigInteger currentBaseFee;
+	public final BigInteger currentRandom;
+	public final BigInteger currentWithdrawalsRoot;
 	/**
 	 * Hash of the previous block.
 	 */
@@ -40,7 +42,7 @@ public class Environment {
 	public final Map<BigInteger,BigInteger> blockHashes;
 
 	public Environment(BigInteger currentCoinbase, BigInteger currentDifficulty, BigInteger currentGasLimit,
-			BigInteger currentNumber, BigInteger currentTimestamp, BigInteger currentBaseFee, BigInteger previousHash,
+			BigInteger currentNumber, BigInteger currentTimestamp, BigInteger currentBaseFee,  BigInteger currentRandom, BigInteger currentWithdrawalsRoot, BigInteger previousHash,
 			Map<BigInteger, BigInteger> blockHashes) {
 		this.currentCoinbase = currentCoinbase;
 		this.currentDifficulty = currentDifficulty;
@@ -48,6 +50,8 @@ public class Environment {
 		this.currentNumber = currentNumber;
 		this.currentTimestamp = currentTimestamp;
 		this.currentBaseFee = currentBaseFee;
+		this.currentRandom = currentRandom;
+		this.currentWithdrawalsRoot = currentWithdrawalsRoot;
 		this.previousHash = previousHash;
 		this.blockHashes = new HashMap<>(blockHashes);
 	}
@@ -60,6 +64,9 @@ public class Environment {
 		json.put("currentNumber", Hex.toHexString(currentNumber));
 		json.put("currentTimestamp", Hex.toHexString(currentTimestamp));
 		json.put("currentBaseFee", Hex.toHexString(currentBaseFee));
+		json.put("currentRandom", Hex.toHexString(currentRandom));
+		json.put("currentWithdrawalsRoot", Hex.toHexString(currentWithdrawalsRoot));
+		json.put("withdrawals", new JSONArray()); // FIXME: this looks wrong.
 		json.put("previousHash", Hex.toHexString(previousHash));
 		if(!blockHashes.isEmpty()) {
 			JSONObject st = new JSONObject();
@@ -79,8 +86,11 @@ public class Environment {
 		BigInteger timeStamp = Hex.toBigInt(json.getString("currentTimestamp"));
 		BigInteger baseFee = Hex.toBigInt(json.getString("currentBaseFee"));
 		BigInteger prevHash = Hex.toBigInt(json.getString("previousHash"));
+		BigInteger random = Hex.toBigInt(json.getString("currentRandom"));
+		BigInteger withdrawals = Hex.toBigInt(json.getString("currentWithdrawalsRoot"));
 		// Construct blockHashes
 		HashMap<BigInteger,BigInteger> hashes = new HashMap<>();
+
 		if(json.has("blockHashes")) {
 			JSONObject map = json.getJSONObject("blockHashes");
 			JSONArray names = map.names();
@@ -94,6 +104,6 @@ public class Environment {
 			}
 		}
 		// Done
-		return new Environment(coinBase, difficulty, gasLimit, number, timeStamp, baseFee, prevHash, hashes);
+		return new Environment(coinBase, difficulty, gasLimit, number, timeStamp, baseFee, random, withdrawals, prevHash, hashes);
 	}
 }

--- a/src/main/java/evmtools/evms/Geth.java
+++ b/src/main/java/evmtools/evms/Geth.java
@@ -110,7 +110,7 @@ public class Geth extends AbstractExecutable {
 		String txsFile = null;
 		try {
 			tempDir = createTemporaryDirectory();
-			envFile = createEnvFile(tempDir,env);
+			envFile = createEnvFile(tempDir,env,fork);
 			allocFile = createAllocFile(tempDir,pre);
 			txsFile = createTransactionsFile(tempDir,tx);
 			// Build up the command
@@ -492,9 +492,12 @@ public class Geth extends AbstractExecutable {
 		return createTemporaryFile(dir, "alloc.json", bytes);
 	}
 
-	private static String createEnvFile(Path dir, Environment env)
+	private static String createEnvFile(Path dir, Environment env, String fork)
 			throws JSONException, IOException, InterruptedException {
 		JSONObject json = env.toJSON();
+		if(isPostMerge(fork)) {
+			json.remove("currentDifficulty");
+		}
 		byte[] bytes = json.toString(2).getBytes();
 		return createTemporaryFile(dir, "env.json", bytes);
 	}
@@ -519,6 +522,18 @@ public class Geth extends AbstractExecutable {
 
 	private static Path createTemporaryDirectory() throws IOException {
 		return Files.createTempDirectory("geth");
+	}
+
+	public static boolean isPostMerge(String fork) {
+		switch(fork.toUpperCase()) {
+		case "BERLIN":
+		case "LONDON":
+			return false;
+		case "SHANGHAI":
+			return true;
+		default:
+			throw new IllegalArgumentException("unknown fork encountered \"" + fork + "\"");
+		}
 	}
 
 	/**


### PR DESCRIPTION
This updates the tool base to support the slightly extended StateTest format.  For example, this now includes fields such as `currentWithdrawalsRoot` and `currentRandom` which are needed post-merge.

At this stage, there is an outstanding issue related to hashes however, in that Geth is expecting some to be provided ... but they are not present in the state test files themselves.  Potentially they need to be generated by the tool?